### PR TITLE
Remove partner limit of 15

### DIFF
--- a/page-partners.hbs
+++ b/page-partners.hbs
@@ -2,7 +2,7 @@
     <div class="inner posts">
         <div class="post-feed{{#match @custom.feed_layout " List"}} list{{/match}}">
 
-            {{#get "posts" filter="tags:hash-mainpartnerpage" as |mainpartners|}}
+            {{#get "posts" limit="all" filter="tags:hash-mainpartnerpage" as |mainpartners|}}
             {{#foreach mainpartners}}
 
             <article class="page-card mainpartner-card">
@@ -25,7 +25,7 @@
 
         <div class="post-feed{{#match @custom.feed_layout " List"}} list{{/match}} pages">
             
-            {{#get "posts" filter="tags:hash-partnerpage+tags:-hash-mainpartnerpage" as |partners|}}
+            {{#get "posts" limit="all" filter="tags:hash-partnerpage+tags:-hash-mainpartnerpage" as |partners|}}
             {{#foreach partners}}
         
             <article class="page-card post tag-senior">


### PR DESCRIPTION
Allow more than 15 partners on the https://rekry.tietokilta.fi/partners/ page. Changes are done based on this documentation  https://ghost.org/docs/themes/helpers/get/